### PR TITLE
Add option to only keep `x` latest backup objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ general {
     # Enable/Disable upload via S3
     B:enable=true
 
+    # The maximum amount of backup objects to keep in bucket (0 = all)
+    # Min: 0
+    # Max: 2147483647
+    I:keep_latest=10
+
     # Secret key is the password to your account
     S:secret_key=zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+
+volumes:
+  minio:
+
+services:
+  minio:
+    image: "minio/minio:latest"
+    ports:
+       - "9000:9000"
+       - "9001:9001"
+    volumes:
+      - "minio:/data"
+    environment:
+      MINIO_ACCESS_KEY: "dev_access_key"
+      MINIO_SECRET_KEY: "dev_secret_key"
+    command: server /data --console-address 0.0.0.0:9001

--- a/src/main/java/ru/lionzxy/aromas3/AromaBackupConfig.java
+++ b/src/main/java/ru/lionzxy/aromas3/AromaBackupConfig.java
@@ -18,4 +18,8 @@ public class AromaBackupConfig {
 
     public static String bucket_name = "minecraft";
     public static boolean delete_after_upload = true;
+
+    @Config.RangeInt(min = 0)
+    @Config.Comment("The maximum amount of backup objects to keep in bucket (0 = all)")
+    public static int keep_latest = 10;
 }


### PR DESCRIPTION
I've added an option in the config which allows to set an amount of latest backup objects to be kept in the object storage. All older objects exceeding this threshold will be deleted after the next backup creation.

Additionally, I've added a `docker-compose.yml` configuration for easily setting up a minio instance for development or testing.

Edit: Also updated the config example in the readme according to the new config entry.